### PR TITLE
Handle removed frames

### DIFF
--- a/index.js
+++ b/index.js
@@ -248,7 +248,13 @@ module.exports = async function (config) {
       var marker = markers[markerIndex];
       markerIndex++;
       if (marker.type === 'Capture') {
-        await timeHandler.goToTimeAndAnimateForCapture(browserFrames, marker.time);
+        await timeHandler.goToTimeAndAnimateForCapture(browserFrames, marker.time).catch((err) => {
+          if (err.message.includes('Execution context was destroyed')) {
+            log(err.message);
+            return;
+          }
+          throw err;
+        });
         var skipCurrentFrame;
         if (config.shouldSkipFrame) {
           skipCurrentFrame = await config.shouldSkipFrame({

--- a/lib/overwrite-time.js
+++ b/lib/overwrite-time.js
@@ -53,6 +53,10 @@ const goToTime = async function (browserFrames, time) {
 const goToTimeAndAnimate = async function (browserFrames, time) {
   // Goes to a certain time. Can't go backwards
   return Promise.all(browserFrames.map(function (frame) {
+
+    // Don't run processing functions on detached frames (e.g. iframes that have been removed)
+    if (frame._detached) return;
+
     return frame.evaluate(function (ms) {
       window.timeweb.processUntilTime(ms);
       return window.timeweb.runFramePreparers(ms, window.timeweb.runAnimationFrames);

--- a/lib/overwrite-time.js
+++ b/lib/overwrite-time.js
@@ -60,7 +60,15 @@ const goToTimeAndAnimate = async function (browserFrames, time) {
     return frame.evaluate(function (ms) {
       window.timeweb.processUntilTime(ms);
       return window.timeweb.runFramePreparers(ms, window.timeweb.runAnimationFrames);
-    }, time);
+    }, time).catch((error) => {
+
+      // Add the URL of a frame to thrown error messages for context
+      if (error.message.endsWith('.')) {
+        throw new Error(error.message.slice(0, -1) + ' in ' + frame._url);
+      }
+
+      throw error;
+    });
   }));
 };
 


### PR DESCRIPTION
### Checklist
- [X] Code changes are only for the relevant bug fix or feature
- [X] New code lints (via `npm run lint`) without any errors or warnings
- [X] The corresponding issue is #TBD

### Description
Catches exceptions related to destroyed contexts, mostly occurring when iframes are removed from the page, and continues gracefully.

The error message check for "Execution context was destroyed" mirrors Puppeteer's own check: https://github.com/puppeteer/puppeteer/blob/08e9978ce662cf1c2c2708f7e6098cbea328cbe2/src/common/DOMWorld.ts#L553-L555